### PR TITLE
feat: command to open menu anywhere

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -5,6 +5,7 @@ local isLoggedIn = LocalPlayer.state.isLoggedIn
 local dynamicMenuItems = {}
 local PlayerJob = {}
 local PlayerGang = {}
+local tab = nil
 
 local function AttachObject()
 	tab = CreateObject(GetHashKey("prop_cs_tablet"), 0, 0, 0, true, true, true)
@@ -302,9 +303,8 @@ end)
 AddEventHandler('onClientResourceStart', function(resource)
     if cache.resource ~= resource then return end
     initZones()
-    PlayerData = QBX.PlayerData
-    PlayerJob = PlayerData.job
-    PlayerGang = PlayerData.gang
+    PlayerJob = QBX.PlayerData.job
+    PlayerGang = QBX.PlayerData.gang
 end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,4 +1,5 @@
 return {
     useTarget = false, -- Enables ox_target interactions
     debugPoly = false,
+    holdTablet = true
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,4 +1,6 @@
 return {
+    commandName = 'tablet',
+    commandHelp = 'Este comando gerencia a organização (Somente Chefe).',
     discordWebhook = nil, -- Replace nil with your webhook if you chose to use discord logging over ox_lib logging
 
     -- While the config boss menu creation still works, it is recommended to use the runtime export instead.

--- a/server/main.lua
+++ b/server/main.lua
@@ -223,3 +223,9 @@ local function registerBossMenu(menuInfo)
 end
 
 exports('RegisterBossMenu', registerBossMenu)
+
+lib.addCommand(config.commandName, {
+    help = config.commandHelp
+}, function(source, args, raw)
+    TriggerClientEvent('qbx_management:client:OpenBossMenu', source)
+end)


### PR DESCRIPTION
## Description

Adiciona a opção para abrir o menu em qualquer lugar, fazendo o ped segurar um tablet enquanto estiver com o menu aberto.

Testado com job + gang

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
